### PR TITLE
Add extra debug output for segmentation bbox

### DIFF
--- a/segment_then_landmark.py
+++ b/segment_then_landmark.py
@@ -66,8 +66,9 @@ def main(image_path, seg_weights, landmark_weights):
     mask.save("debug_mask.png")
 
     # Determine crop region and show bbox
+    bbox = mask.getbbox()
+    print("Mask bounding box:", bbox)
     cropped, offset, crop_size = crop_to_mask(image, mask)
-    print(f"Mask bounding box: {offset[0], offset[1], offset[0]+crop_size[0], offset[1]+crop_size[1]}")
 
     # Debug: save cropped region
     cropped.save("debug_cropped.png")


### PR DESCRIPTION
## Summary
- print bounding box from segmentation mask before cropping
- keep saving debug mask and overlay images

## Testing
- `python3 -m py_compile segment_then_landmark.py`

------
https://chatgpt.com/codex/tasks/task_e_6888ea6668fc8324896de432399d2124